### PR TITLE
bpo-12178: Handle escape character

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -197,6 +197,8 @@ class Test_Csv(unittest.TestCase):
                            escapechar='\\', quoting=csv.QUOTE_NONE)
         self._write_test(['\\', 'a'], '\\\\,a',
                          escapechar='\\', quoting=csv.QUOTE_NONE)
+        self._write_test([',\\', 'a'], '",\\\\",a',
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
 
     def test_write_escape_escapechar(self):
         tests = [


### PR DESCRIPTION
Hey.
I noticed a comment in the cpython repository discussing this PR which pointed out a potential bug: https://github.com/python/cpython/pull/13710/files/4c4683677a32232d0900854c41f8d6f057d11869#diff-ff5a6b2bf6c6b916d131c6da1da9360f
It seemed like a small fix, and I implemented it as an exercise and with some hope of contributing a bit.

I will understand if you don't wish to accept this PR for any reason.